### PR TITLE
Enable continue button for empty dao proposals

### DIFF
--- a/src/screens/CurrentEntity/Dashboard/DAODashboard/Governance/CreateProposal/SetupProposalActions/SetupActions.tsx
+++ b/src/screens/CurrentEntity/Dashboard/DAODashboard/Governance/CreateProposal/SetupProposalActions/SetupActions.tsx
@@ -33,7 +33,7 @@ const SetupActions: React.FC = () => {
         <Button variant='secondary' onClick={handleBack}>
           Back
         </Button>
-        <Button onClick={handleContinue} disabled={validActions.length === 0}>
+        <Button onClick={handleContinue}>
           Continue
         </Button>
       </FlexBox>


### PR DESCRIPTION
## Scope
This PR addresses an issue where the "Continue" button was disabled on DAO Group proposals when no actions were defined.

## Work Done
Removed the `disabled` prop from the "Continue" button in `src/screens/CurrentEntity/Dashboard/DAODashboard/Governance/CreateProposal/SetupProposalActions/SetupActions.tsx`. This prop was conditionally disabling the button when `validActions.length` was 0.

## Steps to Test
1.  Navigate to the DAO Group proposal creation flow.
2.  Proceed to the "Setup Actions" step.
3.  Do not add any actions.
4.  Verify that the "Continue" button is now enabled.

## Screenshots
N/A

---
<a href="https://cursor.com/background-agent?bcId=bc-09ccad80-30df-41e0-969b-58740ab8550b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-09ccad80-30df-41e0-969b-58740ab8550b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

