### PR TITLE
Enable continue button for empty dao proposals

### DIFF
--- a/src/screens/CurrentEntity/Dashboard/DAODashboard/Governance/CreateProposal/SetupProposalActions/SetupActions.tsx
+++ b/src/screens/CurrentEntity/Dashboard/DAODashboard/Governance/CreateProposal/SetupProposalActions/SetupActions.tsx
@@ -33,7 +33,7 @@ const SetupActions: React.FC = () => {
         <Button variant='secondary' onClick={handleBack}>
           Back
         </Button>
-        <Button onClick={handleContinue} disabled={validActions.length === 0}>
+        <Button onClick={handleContinue}>
           Continue
         </Button>
       </FlexBox>


### PR DESCRIPTION
## Scope
This PR affects the DAO Group proposal creation flow, specifically the "Setup Actions" step.

## Work Done
The "Continue" button on the "Setup Actions" step of DAO Group proposal creation is now enabled regardless of whether any actions have been added. Previously, it was disabled when `validActions.length === 0`.

## Steps to Test
1. Navigate to the DAO Group proposal creation.
2. Proceed to the "Setup Actions" step.
3. Verify that the "Continue" button is enabled even if no actions are added.

## Screenshots
N/A

---
<a href="https://cursor.com/background-agent?bcId=bc-08b14723-e2da-4fca-9426-c83319dc1a63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-08b14723-e2da-4fca-9426-c83319dc1a63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

