### PR TITLE
Enable Continue Button for DAO Group Proposals

### DIFF
--- a/src/screens/CurrentEntity/Dashboard/DAODashboard/Governance/CreateProposal/SetupProposalActions/SetupActions.tsx
+++ b/src/screens/CurrentEntity/Dashboard/DAODashboard/Governance/CreateProposal/SetupProposalActions/SetupActions.tsx
@@ -33,7 +33,7 @@ const SetupActions: React.FC = () => {
         <Button variant='secondary' onClick={handleBack}>
           Back
         </Button>
-        <Button onClick={handleContinue} disabled={validActions.length === 0}>
+        <Button onClick={handleContinue}>
           Continue
         </Button>
       </FlexBox>


### PR DESCRIPTION
This PR enables the 'continue' button on DAO Group proposals even when there are no actions.